### PR TITLE
updated libraries to include -dev

### DIFF
--- a/htdocs/download.html
+++ b/htdocs/download.html
@@ -111,7 +111,7 @@
           <br></span>
           For Debian based systems, type this at the command line:<br>
           <span class="code" style="margin-left : 20px;">
-            sudo apt-get install libsdl1.2debian libsdl-image1.2 zlib1g libogg0 libvorbis0a libopenal1 libcurl4
+            sudo apt install libsdl1.2-dev libsdl-image1.2-dev zlib1g-dev libogg-dev libvorbis-dev libopenal-dev libcurl4-openssl-dev zlibc clang
           </span>
         </p>
         <p>


### PR DESCRIPTION
I believe these are the required libraries needed to compile for Debian. -dev was needed on a lot of them. I also added clang.