### PR TITLE
AssaultCube - Updates #1

### DIFF
--- a/htdocs/SSI-HTML/download_box.html
+++ b/htdocs/SSI-HTML/download_box.html
@@ -14,16 +14,6 @@
           </tr>
           <tr>
             <td>
-              <a href="https://github.com/assaultcube/AC/releases/download/v1.3.0.0/AssaultCube_v1.3.0.0_LocdownEdition.dmg">
-              <img src="docs/images/apple.png" alt="Mac OS" width="40px" height="40px" title="Supports Mac OS X 10.6 (or higher)"></a>
-            </td>
-            <td>
-              <a href="https://github.com/assaultcube/AC/releases/download/v1.3.0.0/AssaultCube_v1.3.0.0_LocdownEdition.dmg"
-              title="Supports Mac OS X 10.6 (or higher)">Apple Mac OS X</a>
-            </td>
-          </tr>
-          <tr>
-            <td>
               <a href="https://github.com/assaultcube/AC/releases/download/v1.3.0.0/AssaultCube_v1.3.0.0_LockdownEdition.tar.bz2">
               <img src="docs/images/linux.png" alt="Linux" width="40px" height="40px" title="Linux"></a>
             </td>
@@ -33,11 +23,21 @@
             </td>
           </tr>
           <tr>
+            <td>
+              <a href="https://github.com/assaultcube/AC/releases/download/v1.3.0.0/AssaultCube_v1.3.0.0_LocdownEdition.dmg">
+              <img src="docs/images/apple.png" alt="macOS" width="40px" height="40px" title="Supports Mac OS X 10.6 (or higher)"></a>
+            </td>
+            <td>
+              <a href="https://github.com/assaultcube/AC/releases/download/v1.3.0.0/AssaultCube_v1.3.0.0_LocdownEdition.dmg"
+              title="Supports macOS 10.6 (or higher)">Apple Mac OS</a>
+            </td>
+          </tr>
+          <tr>
             <td colspan="2">
               <a href='https://play.google.com/store/apps/details?id=net.cubers.assaultcube&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'>
               <!-- Google Play and the Google Play logo are trademarks of Google LLC. -->
 	      <!-- https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png -->
-              <img alt="Get it on Google Play" src="docs/images/android.google-playstore.png" style="max-width:100%"></a>
+              <img alt="Get it on Google Play" src="docs/images/android.google-playstore.png" title="Supports Android 7 (or higher)" style="max-width:100%"></a>
             </td>
           </tr>
         </table>

--- a/htdocs/SSI-HTML/hotlinks_box.html
+++ b/htdocs/SSI-HTML/hotlinks_box.html
@@ -6,7 +6,7 @@
           <li><a href="/irc.html">IRC</a></li>
           <li><a href="https://wiki.cubers.net/">Wiki</a></li>
           <li><a href="/docs">Official documentation</a></li>
-          <li><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=FEUVMQREJMQT2&source=url">Donate to this project</a></li>
+          <li><a href="https://www.paypal.com/donate/?hosted_button_id=B53CR9HGH7UH2">Donate to this project</a></li>
           <li><a href="https://github.com/assaultcube/AC/issues">File a Bug Report!</a></li>
         </ul>
         <ul>

--- a/htdocs/download.html
+++ b/htdocs/download.html
@@ -61,7 +61,7 @@
           <tr>
             <td>
               <a href="https://github.com/assaultcube/AC/releases/download/v1.3.0.0/AssaultCube_v1.3.0.0_LockdownEdition.exe">
-                <img src="docs/images/windows.png" alt="Windows" width="40px" height="40px" title="Supports Windows 2000/XP/Vista/7/8/10">
+                <img src="docs/images/windows.png" alt="Windows" width="40px" height="40px" title="Supports Windows 2000/XP/Vista/7/8/10/11">
                 <br>
                 Microsoft<br>Windows
               </a>
@@ -75,9 +75,16 @@
             </td>
             <td>
               <a href="https://github.com/assaultcube/AC/releases/download/v1.3.0.0/AssaultCube_v1.3.0.0_LocdownEdition.dmg">
-                <img src="docs/images/macos.png" alt="macOS" width="40px" height="40px" title="Supports macOS 10.14 (or higher)">
+                <img src="docs/images/apple.png" alt="macOS" width="40px" height="40px" title="Supports macOS 10.6 (or higher)">
                 <br>
                 Apple macOS
+              </a>
+            </td>
+            <td>
+              <a href="https://play.google.com/store/apps/details?id=net.cubers.assaultcube&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1">
+                <img src="docs/images/android.google-playstore.png" alt="Android" width="160px" height="70px" title="Supports Android 7 (or higher)">
+                <br>
+                Microsoft<br>Android
               </a>
             </td>
           </tr>

--- a/htdocs/download.html
+++ b/htdocs/download.html
@@ -75,7 +75,7 @@
             </td>
             <td>
               <a href="https://github.com/assaultcube/AC/releases/download/v1.3.0.0/AssaultCube_v1.3.0.0_LocdownEdition.dmg">
-                <img src="docs/images/apple.png" alt="macOS" width="40px" height="40px" title="Supports macOS 10.6 (or higher)">
+                <img src="docs/images/macos.png" alt="macOS" width="40px" height="40px" title="Supports macOS 10.6 (or higher)">
                 <br>
                 Apple macOS
               </a>

--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -77,7 +77,7 @@
           <li>Lightweight size, only about 50 MB to download, plus additional maps average 20 KB each!</li>
           <li>With the correct settings, it can run on old hardware (Pentium III and above).</li>
           <li>
-            Officially runs on <span title="Windows: 2000/XP/Vista/7/8/10, Linux, Mac OS X: 10.6+"
+            Officially runs on <span title="Supports: Windows 2000/XP/Vista/7/8/10/11, Linux, macOS 10.6+"
             class="titletext"> most major systems</span>, and maybe even some
             <a href="docs/getstarted.html">non-major ones</a>?
           </li>


### PR DESCRIPTION
Requesting merge of update #1.

I noticed a issues for the AssaultCube website and decided to provide some fixes for them.
<hr>

# htdocs/index.html
1. Update `most major systems` title to include `Windows 11`

# htdocs/download.html
1. Update Microsoft Windows img title to include `Windows 11`
2. Update Apple macOS img title to update version minimum `10.14` => `10.6`
3. Change Apple macOS img src `macos.png` => `apple.png`
4. Add download link for Google Play
5. Add default img title for Google Play

# htdocs/SSI-HTML/download_box.html
1. Switch Apple and Linux column priority to match download page column priority
2. Update `macOS X` text to `macOS`
3. Update `macOS X` alt to `macOS`
4. Update `macOS X` img title to `macOS`
5. Add default img title for Google Play

# htdocs/SSI-HTML/hotlinks_box.html
1. Update invalid `Hot links => Donate to this project` PayPal link to match working htdocs/SSI-HTML/donate_box.html `Support this project` PayPal link