### PR TITLE
Remove broken URLs on team.html

### DIFF
--- a/htdocs/docs/team.html
+++ b/htdocs/docs/team.html
@@ -200,13 +200,13 @@
         <h4>Texture resources</h4>
         <table class="resources">
           <tr>
-            <td><a href="http://www.articool.de">Articool</a></td>
+            <td>Articool</td>
             <td class="c1"><a href="http://www.boeckmania.de">Boeck</a></td>
             <td>Craig Fortune</td>
-            <td class="c1"><a href="http://www.digitalflux.com">Digital Flux</a></td>
+            <td class="c1">Digital Flux</td>
           </tr>
           <tr>
-            <td class="c1"><a href="http://www.mayang.com">www.mayang.com</a></td>
+            <td class="c1">www.mayang.com</td>
             <td>www.afflict.net</td>
             <td class="c1">Golgotha team</td>
             <td>NOCTUA graphics</td>


### PR DESCRIPTION
Removed broken links from the Texture resources section on the team page. The removed URLs are either up for sale or link to a spam site.